### PR TITLE
[Reafactor] react-icon 라이브러리 삭제

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
                 "keytar": "^7.9.0",
                 "lucide-react": "^0.536.0",
                 "next-themes": "^0.4.6",
-                "react-icons": "^5.5.0",
                 "semver": "^7.7.2",
                 "sonner": "^2.0.7",
                 "tailwind-merge": "^3.3.1",
@@ -14611,15 +14610,6 @@
             },
             "peerDependencies": {
                 "react": "^19.1.0"
-            }
-        },
-        "node_modules/react-icons": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
-            "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
-            "license": "MIT",
-            "peerDependencies": {
-                "react": "*"
             }
         },
         "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
         "keytar": "^7.9.0",
         "lucide-react": "^0.536.0",
         "next-themes": "^0.4.6",
-        "react-icons": "^5.5.0",
         "semver": "^7.7.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",

--- a/src/renderer/src/features/darkmode/ui/DarkModeButton.tsx
+++ b/src/renderer/src/features/darkmode/ui/DarkModeButton.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react'
 import { trackEvent } from '@aptabase/electron/renderer'
-import { MdDarkMode, MdLightMode } from 'react-icons/md'
+import { Moon, Sun } from 'lucide-react'
 
 export function DarkModeButton() {
     const [darkMode, setDarkMode] = useState(() => {
@@ -31,7 +31,7 @@ export function DarkModeButton() {
                 className="relative flex h-6 w-12 items-center justify-center rounded-full bg-yellow-400 transition-colors duration-300 dark:bg-gray-500"
             >
                 <div className={`absolute h-5 w-5 rounded-full bg-white p-1 transition-transform duration-300 ${darkMode ? '-translate-x-3' : 'translate-x-3'}`}>
-                    {darkMode ? <MdDarkMode className="h-full w-full text-gray-500" /> : <MdLightMode className="h-full w-full text-yellow-400" />}
+                    {darkMode ? <Moon strokeWidth={3} className="h-full w-full text-gray-500" /> : <Sun strokeWidth={3} className="h-full w-full text-yellow-500" />}
                 </div>
             </button>
         </div>

--- a/src/renderer/src/features/event/ui/delete-event/DeleteEventButton.tsx
+++ b/src/renderer/src/features/event/ui/delete-event/DeleteEventButton.tsx
@@ -1,7 +1,7 @@
-import { IoCloseOutline } from 'react-icons/io5'
 import { useDeleteEvent } from './DeleteEventButton.mutation'
 import { toast } from 'sonner'
 import { trackEvent } from '@aptabase/electron/renderer'
+import { X } from 'lucide-react'
 
 export function DeleteEventButton({ eventId }: { eventId: string }) {
     const { deleteEvent } = useDeleteEvent()
@@ -15,7 +15,7 @@ export function DeleteEventButton({ eventId }: { eventId: string }) {
                 toast.success('일정이 삭제되었습니다.')
             }}
         >
-            <IoCloseOutline />
+            <X strokeWidth={1.5} size={16} />
         </button>
     )
 }

--- a/src/renderer/src/widgets/Header/ui/Header.tsx
+++ b/src/renderer/src/widgets/Header/ui/Header.tsx
@@ -1,8 +1,7 @@
-import { SlArrowLeft, SlArrowRight } from 'react-icons/sl'
-
 import { FlipButton } from '@/features/flip'
 import { RefreshButton } from '@/features/refresh'
 import { HeaderDropDown } from './HeaderDropDown'
+import { ChevronLeft, ChevronRight } from 'lucide-react'
 
 interface CalendarHeaderProps {
     displayMonth: number
@@ -13,15 +12,15 @@ interface CalendarHeaderProps {
 export function Header({ displayMonth, year, handlePrevMonth, handleNextMonth }: CalendarHeaderProps) {
     return (
         <div className="bg-primary text-primary mb-2 flex w-full flex-row items-center justify-between rounded-xl px-6 py-3">
-            <div className="flex flex-row items-center gap-px">
+            <div className="flex flex-row items-center">
                 <div className="p-2">
-                    <SlArrowLeft onClick={handlePrevMonth} />
+                    <ChevronLeft strokeWidth={1.25} onClick={handlePrevMonth} />
                 </div>
-                <div className="px-4 text-xl font-semibold">
+                <div className="min-w-[16d0px] px-4 text-center text-xl font-semibold">
                     {year}년 {displayMonth.toString().padStart(2, '0')}월
                 </div>
                 <div className="p-2">
-                    <SlArrowRight onClick={handleNextMonth} />
+                    <ChevronRight strokeWidth={1.25} onClick={handleNextMonth} />
                 </div>
             </div>
 


### PR DESCRIPTION
## 📌 제목

react-icon 라이브러리삭제

## 📝 작업 내용

- react-icon 라이브러리를 사용하는 아이콘을 lucide-react로 변겨함
- react-icon 삭제를 통해 패키지 사이지 80mb 감소

## 🔗 관련 이슈

Close #43 

## ✅ 체크리스트

- [ ] 테스트 코드 작성
- [ ] 로컬 환경에서 정상 동작 확인
- [ ] ESLint, Prettier 체크 통과
- [ ] 커밋 메시지 규칙 준수

## 📸 스크린샷 (선택)

<!-- UI 변경 시 스크린샷 첨부 -->
