### PR TITLE
[Fix] 다크모드 아이콘 색상 채우기

### DIFF
--- a/src/renderer/src/features/darkmode/ui/DarkModeButton.tsx
+++ b/src/renderer/src/features/darkmode/ui/DarkModeButton.tsx
@@ -31,7 +31,11 @@ export function DarkModeButton() {
                 className="relative flex h-6 w-12 items-center justify-center rounded-full bg-yellow-400 transition-colors duration-300 dark:bg-gray-500"
             >
                 <div className={`absolute h-5 w-5 rounded-full bg-white p-1 transition-transform duration-300 ${darkMode ? '-translate-x-3' : 'translate-x-3'}`}>
-                    {darkMode ? <Moon strokeWidth={3} className="h-full w-full text-gray-500" /> : <Sun strokeWidth={3} className="h-full w-full text-yellow-500" />}
+                    {darkMode ? (
+                        <Moon strokeWidth={3} className="h-full w-full text-gray-500" fill="currentColor" />
+                    ) : (
+                        <Sun strokeWidth={3} className="h-full w-full text-yellow-500" fill="currentColor" />
+                    )}
                 </div>
             </button>
         </div>


### PR DESCRIPTION
## 📌 제목

<!-- 어떤 작업인지 간단히 설명 -->
다크모드 변경 아이콘의 색상을 채웁니다.

## 📝 작업 내용



## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적습니다 -->

Close #51 

## ✅ 체크리스트

- [ ] 테스트 코드 작성
- [ ] 로컬 환경에서 정상 동작 확인
- [ ] ESLint, Prettier 체크 통과
- [ ] 커밋 메시지 규칙 준수

## 📸 스크린샷 (선택)

<!-- UI 변경 시 스크린샷 첨부 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **스타일**
  * 다크 모드 버튼의 아이콘 색상 표시를 개선했습니다. 달 및 태양 아이콘이 이제 현재 텍스트 색상을 올바르게 상속하여 테마 전환 시 시각적 일관성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->