### PR TITLE
[Feat] 푸터를 접을 수 있는 기능 추가 및 부분 리팩토링

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "mirinae",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "description": "미리내",
     "main": "./out/main/index.js",
     "author": "Mirinae",

--- a/src/renderer/src/features/darkmode/ui/DarkModeButton.tsx
+++ b/src/renderer/src/features/darkmode/ui/DarkModeButton.tsx
@@ -26,6 +26,7 @@ export function DarkModeButton() {
         <div className="flex flex-row justify-between">
             <label>다크모드</label>
             <button
+                type="button"
                 onClick={toggleDarkMode}
                 onKeyDown={(e) => e.preventDefault()}
                 className="relative flex h-6 w-12 items-center justify-center rounded-full bg-yellow-400 transition-colors duration-300 dark:bg-gray-500"

--- a/src/renderer/src/features/flip/index.tsx
+++ b/src/renderer/src/features/flip/index.tsx
@@ -1,1 +1,2 @@
-export { FlipButton } from './ui/FlipButton';
+export { FlipCalendarButton } from './ui/FlipCalendarButton';
+export { FlipFooterButton } from './ui/FlipFooterButton';

--- a/src/renderer/src/features/flip/ui/FlipCalendarButton.test.tsx
+++ b/src/renderer/src/features/flip/ui/FlipCalendarButton.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { FlipButton } from './FlipButton';
+import { FlipCalendarButton } from './FlipCalendarButton';
 
 const mockFlipCalendar = vi.fn();
 
@@ -16,7 +16,7 @@ describe('FlipButton', () => {
     });
 
     it('버튼이 렌더링 된다', () => {
-        render(<FlipButton />);
+        render(<FlipCalendarButton />);
         const button = screen.getByRole('button');
         expect(button).toBeInTheDocument();
     });

--- a/src/renderer/src/features/flip/ui/FlipCalendarButton.tsx
+++ b/src/renderer/src/features/flip/ui/FlipCalendarButton.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { FoldVertical, UnfoldVertical } from 'lucide-react';
 import { trackEvent } from '@aptabase/electron/renderer';
 
-export function FlipButton() {
+export function FlipCalendarButton() {
     const [isFlip, setIsFlip] = useState(false);
 
     const handleClick = () => {

--- a/src/renderer/src/features/flip/ui/FlipFooterButton.tsx
+++ b/src/renderer/src/features/flip/ui/FlipFooterButton.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 export function FlipFooterButton() {
     const [isFlip, setIsFlip] = useState(false);
     const onClick = () => {
-        setIsFlip(!isFlip);
+        setIsFlip((prev) => !prev);
         document.documentElement.classList.toggle('flip-footer');
     };
 
@@ -11,7 +11,8 @@ export function FlipFooterButton() {
         <div className="flex flex-row justify-between">
             <label>달력만보기</label>
             <button
-                onClick={() => onClick()}
+                type="button"
+                onClick={onClick}
                 onKeyDown={(e) => e.preventDefault()}
                 className={`border-background-secondary relative flex h-6 w-12 items-center justify-center rounded-full transition-colors duration-300 ${isFlip ? 'bg-green-500' : 'bg-zinc-400'}`}
             >

--- a/src/renderer/src/features/flip/ui/FlipFooterButton.tsx
+++ b/src/renderer/src/features/flip/ui/FlipFooterButton.tsx
@@ -1,10 +1,23 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 export function FlipFooterButton() {
     const [isFlip, setIsFlip] = useState(false);
+
+    useEffect(() => {
+        const saved = localStorage.getItem('flipFooter');
+        if (saved === 'true') {
+            setIsFlip(true);
+            document.documentElement.classList.add('flip-footer');
+        }
+    }, []);
+
     const onClick = () => {
-        setIsFlip((prev) => !prev);
-        document.documentElement.classList.toggle('flip-footer');
+        setIsFlip((prev) => {
+            const next = !prev;
+            document.documentElement.classList.toggle('flip-footer', next);
+            localStorage.setItem('flipFooter', next.toString());
+            return next;
+        });
     };
 
     return (
@@ -16,7 +29,7 @@ export function FlipFooterButton() {
                 onKeyDown={(e) => e.preventDefault()}
                 className={`border-background-secondary relative flex h-6 w-12 items-center justify-center rounded-full transition-colors duration-300 ${isFlip ? 'bg-green-500' : 'bg-zinc-400'}`}
             >
-                <div className={`absolute h-5 w-5 rounded-full bg-white p-1 transition-all duration-300 ${isFlip ? 'translate-x-3' : '-translate-x-3'} `} />
+                <div className={`absolute h-5 w-5 rounded-full bg-white p-1 transition-all duration-300 ${isFlip ? 'translate-x-3' : '-translate-x-3'}`} />
             </button>
         </div>
     );

--- a/src/renderer/src/features/flip/ui/FlipFooterButton.tsx
+++ b/src/renderer/src/features/flip/ui/FlipFooterButton.tsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+export function FlipFooterButton() {
+    const [isFlip, setIsFlip] = useState(false);
+    const onClick = () => {
+        setIsFlip(!isFlip);
+        document.documentElement.classList.toggle('flip-footer');
+    };
+
+    return (
+        <div className="flex flex-row justify-between">
+            <label>달력만보기</label>
+            <button
+                onClick={() => onClick()}
+                onKeyDown={(e) => e.preventDefault()}
+                className={`border-background-secondary relative flex h-6 w-12 items-center justify-center rounded-full transition-colors duration-300 ${isFlip ? 'bg-green-500' : 'bg-zinc-400'}`}
+            >
+                <div className={`absolute h-5 w-5 rounded-full bg-white p-1 transition-all duration-300 ${isFlip ? 'translate-x-3' : '-translate-x-3'} `} />
+            </button>
+        </div>
+    );
+}

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -24,14 +24,6 @@ body {
     overflow: hidden !important;
     background: transparent;
 }
-html.resizable {
-    border: 3px dotted #e0e0e0;
-    box-sizing: border-box;
-    padding-bottom: 4px;
-}
-html.disable-click {
-    pointer-events: none;
-}
 
 @theme {
     --color-font-black: #1f2937;

--- a/src/renderer/src/index.css
+++ b/src/renderer/src/index.css
@@ -29,17 +29,6 @@ html.resizable {
     box-sizing: border-box;
     padding-bottom: 4px;
 }
-#calendar-container {
-    width: 100%;
-    transition: all 0.3s ease-in-out;
-}
-html.flip-calendar #calendar-container {
-    scale: 0.95;
-    opacity: 0;
-    margin-top: -16px;
-    transition: all 0.3s ease-in-out;
-    pointer-events: none;
-}
 html.disable-click {
     pointer-events: none;
 }

--- a/src/renderer/src/pages/Calender/index.tsx
+++ b/src/renderer/src/pages/Calender/index.tsx
@@ -9,7 +9,7 @@ export function Calendar() {
     const { days, month, displayMonth, year, handlePrevMonth, handleNextMonth } = useDate();
 
     return (
-        <div>
+        <div className="[html.disable-click_&]:pointer-events-none [html.resizable_&]:box-border [html.resizable_&]:border-4 [html.resizable_&]:border-dotted [html.resizable_&]:border-[#e0e0e0] [html.resizable_&]:pb-4">
             <Header displayMonth={displayMonth} year={year} handleNextMonth={handleNextMonth} handlePrevMonth={handlePrevMonth} />
             <div className="flex flex-1 flex-col transition-all duration-300 ease-in-out [html.flip-calendar_&]:pointer-events-none [html.flip-calendar_&]:-mt-4 [html.flip-calendar_&]:scale-95 [html.flip-calendar_&]:opacity-0">
                 <CalendarGrid days={days} month={month} />

--- a/src/renderer/src/pages/Calender/index.tsx
+++ b/src/renderer/src/pages/Calender/index.tsx
@@ -11,7 +11,7 @@ export function Calendar() {
     return (
         <div>
             <Header displayMonth={displayMonth} year={year} handleNextMonth={handleNextMonth} handlePrevMonth={handlePrevMonth} />
-            <div id="calendar-container">
+            <div className="flex flex-1 flex-col transition-all duration-300 ease-in-out [html.flip-calendar_&]:pointer-events-none [html.flip-calendar_&]:-mt-4 [html.flip-calendar_&]:scale-95 [html.flip-calendar_&]:opacity-0">
                 <CalendarGrid days={days} month={month} />
                 <Footer />
             </div>

--- a/src/renderer/src/widgets/Calendar/ui/CalendarGrid.tsx
+++ b/src/renderer/src/widgets/Calendar/ui/CalendarGrid.tsx
@@ -37,7 +37,7 @@ export function CalendarGrid({ days, month }: Pick<DateProps, 'days' | 'month'>)
                     토
                 </div>
             </div>
-            <div className="grid h-[calc(100vh-20rem)] grid-cols-7 grid-rows-[repeat(6,1fr)]">
+            <div className="grid h-[calc(100vh-20rem)] grid-cols-7 grid-rows-[repeat(6,1fr)] transition-all duration-300 ease-in-out [html.flip-footer_&]:h-[calc(100vh-8rem)]">
                 <Dialog open={open} onOpenChange={setOpen}>
                     {days.map((date, i) => {
                         const isCurrentMonth = date.getMonth() === month;

--- a/src/renderer/src/widgets/Calendar/ui/CalendarGrid.tsx
+++ b/src/renderer/src/widgets/Calendar/ui/CalendarGrid.tsx
@@ -23,7 +23,7 @@ export function CalendarGrid({ days, month }: Pick<DateProps, 'days' | 'month'>)
     };
 
     return (
-        <div className="bg-primary flex w-full flex-col overflow-hidden rounded-xl">
+        <div className="bg-primary flex flex-1 flex-col overflow-hidden rounded-xl">
             <div className="grid grid-cols-7 bg-[#F9FAFB] py-2 text-center font-semibold dark:bg-zinc-800">
                 <div className="text-red-400" aria-label="일요일">
                     일

--- a/src/renderer/src/widgets/Footer/ui/Footer.tsx
+++ b/src/renderer/src/widgets/Footer/ui/Footer.tsx
@@ -58,7 +58,7 @@ export function Footer() {
     const importantEvent = useMemo(() => upcomingEvent.filter((event) => event.colorId === colorId), [upcomingEvent, colorId]);
 
     return (
-        <aside className="mt-2 grid h-48 grid-cols-3 gap-2">
+        <aside className="mt-2 grid h-48 grid-cols-3 gap-2 transition-all duration-300 ease-in-out [html.flip-footer_&]:pointer-events-none [html.flip-footer_&]:h-0 [html.flip-footer_&]:overflow-hidden [html.flip-footer_&]:opacity-0">
             <FooterEvent items={todayEvent} title="오늘의 일정" description="오늘의 일정이 없습니다" />
             <FooterEvent items={upcomingEvent} title="다가오는 일정" description="다가오는 일정이 없습니다" />
             <FooterEvent items={importantEvent} title="중요한 일정" description="중요한 일정이 표시됩니다" headerButton={<PalleteDropdown />} />

--- a/src/renderer/src/widgets/Header/ui/Header.tsx
+++ b/src/renderer/src/widgets/Header/ui/Header.tsx
@@ -11,7 +11,7 @@ export function Header({ displayMonth, year, handlePrevMonth, handleNextMonth }:
                 <div className="p-2">
                     <ChevronLeft strokeWidth={1.25} onClick={handlePrevMonth} />
                 </div>
-                <div className="min-w-[16d0px] px-4 text-center text-xl font-semibold">
+                <div className="min-w-[160px] px-4 text-center text-xl font-semibold">
                     {year}년 {displayMonth.toString().padStart(2, '0')}월
                 </div>
                 <div className="p-2">

--- a/src/renderer/src/widgets/Header/ui/Header.tsx
+++ b/src/renderer/src/widgets/Header/ui/Header.tsx
@@ -1,4 +1,4 @@
-import { FlipButton } from '@/features/flip';
+import { FlipCalendarButton } from '@/features/flip';
 import { RefreshButton } from '@/features/refresh';
 import { HeaderDropDown } from './HeaderDropDown';
 import { ChevronLeft, ChevronRight } from 'lucide-react';
@@ -20,7 +20,7 @@ export function Header({ displayMonth, year, handlePrevMonth, handleNextMonth }:
             </div>
 
             <div className="text-primary flex items-center gap-4">
-                <FlipButton />
+                <FlipCalendarButton />
                 <RefreshButton />
                 <HeaderDropDown />
             </div>

--- a/src/renderer/src/widgets/Header/ui/HeaderDropDown.tsx
+++ b/src/renderer/src/widgets/Header/ui/HeaderDropDown.tsx
@@ -7,6 +7,7 @@ import { DarkModeButton } from '@/features/darkmode';
 import { HolidayButton } from '@/features/event';
 import { MoveActiveButton } from '@/features/move';
 import { EllipsisVertical } from 'lucide-react';
+import { FlipFooterButton } from '@/features/flip';
 
 export function HeaderDropDown() {
     return (
@@ -16,6 +17,7 @@ export function HeaderDropDown() {
             <OpacityButton />
             <DarkModeButton />
             <HolidayButton />
+            <FlipFooterButton />
             <QuitAppButton />
         </DropDown>
     );


### PR DESCRIPTION
## 📌 제목

푸터를 접어 캘린더를 더 넓게 쓸 수 있게 변경

## 📝 작업 내용

- Footer를 접을 수 있는 버튼 및 css 추가
- calendar를 접는 css를 tailwind로 변경

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적습니다 -->

Close #64 

## ✅ 체크리스트

- [ ] 테스트 코드 작성
- [ ] 로컬 환경에서 정상 동작 확인
- [ ] ESLint, Prettier 체크 통과
- [ ] 커밋 메시지 규칙 준수

## 📸 스크린샷 (선택)

<!-- UI 변경 시 스크린샷 첨부 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 캘린더용 버튼(FlipCalendarButton)과 하단 토글(FlipFooterButton)이 추가되어 헤더와 드롭다운에 적용됩니다.

* **스타일**
  * 푸터에 부드러운 전환 효과 및 플립 상태 스타일이 추가되었습니다.
  * 캘린더 컨테이너의 일부 애니메이션/가시성 관련 스타일이 제거되어 표시 동작이 변경됩니다.

* **버그 수정 / 접근성**
  * 다크모드 버튼에 명시적 버튼 타입(type="button")이 추가되었습니다.

* **Chores**
  * 버전이 0.1.2로 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->