### PR TITLE
[Feat] 일정을 시간순으로 자동 정렬하게 수정, 1시간 단위 새로고침

### DIFF
--- a/src/renderer/src/features/event/api/useGoogleCalendar.tsx
+++ b/src/renderer/src/features/event/api/useGoogleCalendar.tsx
@@ -1,56 +1,62 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
 import { useShowHoliday } from '@/features/event/model/ShowHolidayContext';
-
 import { CalendarEvent, isHolidayEvent } from '@/shared/types/EventType';
 import { useLogin } from '@/shared/hooks/useLogin';
 
-/**
- * Google Calendar API를 사용하여 캘린더 이벤트를 가져오는 훅입니다.
- * 공휴일 목록과 이벤트 목록을 가져옵니다.
- * @returns {Object} - 캘린더 이벤트 목록과 공휴일 목록
- */
+const CALENDAR_API_URL = 'https://www.googleapis.com/calendar/v3/calendars';
+const REFETCH_INTERVAL = 1000 * 60 * 60; // 1 hour
+
 export function useGoogleCalendar() {
     const { tokens } = useLogin();
     const { isShow } = useShowHoliday();
-    const { data: items } = useQuery({
+
+    const { data: events } = useQuery({
         queryKey: ['googleCalendarEvents'],
         queryFn: async () => {
-            const res = await fetch('https://www.googleapis.com/calendar/v3/calendars/primary/events?maxResults=2500', {
+            const res = await fetch(`${CALENDAR_API_URL}/primary/events?maxResults=2500`, {
+                method: 'GET',
                 headers: { Authorization: `Bearer ${tokens.access_token}` }
             }).then((res) => res.json());
             return res;
         },
         select: (data) => {
-            return data.items.map((event: CalendarEvent) => {
-                return {
-                    ...event,
-                    colorId: event.colorId ?? '1'
-                };
-            });
+            return (data.items || []).map((event: CalendarEvent) => ({
+                ...event,
+                colorId: event.colorId ?? '1'
+            }));
         },
-        enabled: Boolean(tokens.access_token)
+        enabled: Boolean(tokens.access_token),
+        refetchInterval: REFETCH_INTERVAL
     });
-    const { data: holidayItems } = useQuery({
+
+    const { data: holidayEvents } = useQuery({
         queryKey: ['googleCalendarHolidays'],
         queryFn: async () => {
-            const res = await fetch('https://www.googleapis.com/calendar/v3/calendars/ko.south_korea%23holiday%40group.v.calendar.google.com/events?maxResults=2500', {
+            const res = await fetch(`${CALENDAR_API_URL}/ko.south_korea%23holiday%40group.v.calendar.google.com/events?maxResults=2500`, {
+                method: 'GET',
                 headers: { Authorization: `Bearer ${tokens.access_token}` }
             }).then((res) => res.json());
             return res;
         },
         select: (data) => {
-            return data.items
-                .filter((event: CalendarEvent) => isHolidayEvent(event))
-                .map((event: CalendarEvent) => {
-                    return { ...event, colorId: '10' };
-                });
+            return (data.items || []).filter((event: CalendarEvent) => isHolidayEvent(event)).map((event: CalendarEvent) => ({ ...event, colorId: '10' }));
         },
         enabled: Boolean(tokens.access_token)
     });
-    const mergedItems = isShow ? [...(holidayItems ?? []), ...(items ?? [])] : (items ?? []); // event와 holiday를 합침 (공휴일표시 여부에 따라 필터링)
+
+    const mergedEvents = isShow ? [...(holidayEvents ?? []), ...(events ?? [])] : (events ?? []);
+
+    const sortedEventsOrderByDate = useMemo(() => {
+        return [...mergedEvents].sort((a, b) => {
+            const startA = a.start.dateTime ?? a.start.date;
+            const startB = b.start.dateTime ?? b.start.date;
+            return startA.localeCompare(startB);
+        });
+    }, [mergedEvents]);
 
     return {
-        items: mergedItems
+        items: sortedEventsOrderByDate
     };
 }

--- a/src/renderer/src/features/event/lib/createEventBody.ts
+++ b/src/renderer/src/features/event/lib/createEventBody.ts
@@ -8,7 +8,7 @@ interface EventBodyParams {
     colorId: string;
     allDay: boolean;
 }
-export function createEventBody({ date, start, end, summary, colorId, allDay }: EventBodyParams) {
+export function createEventBody({ date, start, end, summary, allDay, colorId = '1' }: EventBodyParams) {
     if (allDay) {
         const startDate = formatDateLocal(date);
         const endDateObj = new Date(date);
@@ -19,7 +19,7 @@ export function createEventBody({ date, start, end, summary, colorId, allDay }: 
             summary,
             start: { date: startDate },
             end: { date: endDate },
-            colorId: colorId || '1'
+            colorId: colorId
         };
     }
 
@@ -31,6 +31,6 @@ export function createEventBody({ date, start, end, summary, colorId, allDay }: 
         summary,
         start: { dateTime: toIsoStringWithOffset(startDateTime), timeZone },
         end: { dateTime: toIsoStringWithOffset(endDateTime), timeZone },
-        colorId: colorId || '1'
+        colorId: colorId
     };
 }

--- a/src/renderer/src/features/event/lib/createEventBody.ts
+++ b/src/renderer/src/features/event/lib/createEventBody.ts
@@ -1,0 +1,36 @@
+import { formatDateLocal, makeDateTime, toIsoStringWithOffset } from '@/shared/lib/dateFunction';
+
+interface EventBodyParams {
+    date: Date;
+    start: string;
+    end: string;
+    summary: string;
+    colorId: string;
+    allDay: boolean;
+}
+export function createEventBody({ date, start, end, summary, colorId, allDay }: EventBodyParams) {
+    if (allDay) {
+        const startDate = formatDateLocal(date);
+        const endDateObj = new Date(date);
+        endDateObj.setDate(endDateObj.getDate() + 1);
+        const endDate = formatDateLocal(endDateObj);
+
+        return {
+            summary,
+            start: { date: startDate },
+            end: { date: endDate },
+            colorId: colorId || '1'
+        };
+    }
+
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const startDateTime = makeDateTime(date, start);
+    const endDateTime = makeDateTime(date, end);
+
+    return {
+        summary,
+        start: { dateTime: toIsoStringWithOffset(startDateTime), timeZone },
+        end: { dateTime: toIsoStringWithOffset(endDateTime), timeZone },
+        colorId: colorId || '1'
+    };
+}

--- a/src/renderer/src/features/event/ui/add-event/AddEventForm.mutation.tsx
+++ b/src/renderer/src/features/event/ui/add-event/AddEventForm.mutation.tsx
@@ -1,7 +1,7 @@
 import { useLogin } from '@/shared/hooks/useLogin';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { CalendarEvent } from '@/shared/types/EventType';
-import { formatDateLocal, makeDateTime } from '@/shared/lib/dateFunction';
+import { formatDateLocal, makeDateTime, toIsoStringWithOffset } from '@/shared/lib/dateFunction';
 
 interface AddEventProp {
     date: Date;
@@ -17,34 +17,9 @@ export function useAddEvent() {
 
     const addEventMutation = useMutation({
         mutationKey: ['addEvent'],
-        mutationFn: async ({ date, start, end, summary, colorId, allDay }: AddEventProp) => {
-            const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
-            let eventData;
-            if (allDay) {
-                // 하루 종일의 경우
-                const startDate = formatDateLocal(date);
-                const endDateObj = new Date(date);
-                endDateObj.setDate(endDateObj.getDate() + 1);
-                const endDate = formatDateLocal(endDateObj);
-                eventData = {
-                    summary,
-                    start: { date: startDate },
-                    end: { date: endDate },
-                    colorId: colorId || '1'
-                };
-            } else {
-                // 아닌 경우
-                const startDateTime = makeDateTime(date, start);
-                const endDateTime = makeDateTime(date, end);
-                eventData = {
-                    summary,
-                    start: { dateTime: startDateTime.toISOString(), timeZone },
-                    end: { dateTime: endDateTime.toISOString(), timeZone },
-                    colorId: colorId || '1'
-                };
-            }
-
+        mutationFn: async (variables: AddEventProp) => {
+            const eventData = createEventBody(variables);
             const response = await fetch(`https://www.googleapis.com/calendar/v3/calendars/primary/events`, {
                 method: 'POST',
                 headers: {
@@ -54,40 +29,20 @@ export function useAddEvent() {
                 body: JSON.stringify(eventData)
             });
 
+            if (!response.ok) {
+                throw new Error('Failed to add event');
+            }
+
             return response.json();
         },
         onMutate: async (newEvent) => {
             await queryClient.cancelQueries({ queryKey: ['googleCalendarEvents'] });
-            const previousData = queryClient.getQueryData<{
-                items: CalendarEvent[];
-            }>(['googleCalendarEvents']);
-            let newEventItem;
-            if (newEvent.allDay) {
-                // 하루 종일의 경우
-                const startDate = formatDateLocal(newEvent.date);
-                const endDateObj = new Date(newEvent.date);
-                endDateObj.setDate(endDateObj.getDate() + 1);
-                const endDate = formatDateLocal(endDateObj);
-                newEventItem = {
-                    id: 'temp-id-' + Date.now(),
-                    summary: newEvent.summary,
-                    start: { date: startDate },
-                    end: { date: endDate },
-                    colorId: newEvent.colorId || '1'
-                };
-            } else {
-                // 아닌 경우
-                const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-                const startDateTime = makeDateTime(newEvent.date, newEvent.start);
-                const endDateTime = makeDateTime(newEvent.date, newEvent.end);
-                newEventItem = {
-                    id: 'temp-id-' + Date.now(),
-                    summary: newEvent.summary,
-                    start: { dateTime: startDateTime.toISOString(), timeZone },
-                    end: { dateTime: endDateTime.toISOString(), timeZone },
-                    colorId: newEvent.colorId || '1'
-                };
-            }
+            const previousData = queryClient.getQueryData<{ items: CalendarEvent[] }>(['googleCalendarEvents']);
+
+            const newEventItem = {
+                ...createEventBody(newEvent),
+                id: `temp-id-${Date.now()}`
+            };
 
             if (previousData) {
                 queryClient.setQueryData(['googleCalendarEvents'], {
@@ -97,8 +52,40 @@ export function useAddEvent() {
 
             return { previousData };
         },
-        onError: (_error, _variables, context: any) => queryClient.setQueryData(['googleCalendarEvents'], context.previousData),
+        onError: (_error, _variables, context) => {
+            if (context?.previousData) {
+                queryClient.setQueryData(['googleCalendarEvents'], context.previousData);
+            }
+        },
         onSettled: () => queryClient.invalidateQueries({ queryKey: ['googleCalendarEvents'] })
     });
+
     return { addEvent: addEventMutation.mutate };
+}
+
+function createEventBody({ date, start, end, summary, colorId, allDay }: AddEventProp) {
+    if (allDay) {
+        const startDate = formatDateLocal(date);
+        const endDateObj = new Date(date);
+        endDateObj.setDate(endDateObj.getDate() + 1);
+        const endDate = formatDateLocal(endDateObj);
+
+        return {
+            summary,
+            start: { date: startDate },
+            end: { date: endDate },
+            colorId: colorId || '1'
+        };
+    }
+
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const startDateTime = makeDateTime(date, start);
+    const endDateTime = makeDateTime(date, end);
+
+    return {
+        summary,
+        start: { dateTime: toIsoStringWithOffset(startDateTime), timeZone },
+        end: { dateTime: toIsoStringWithOffset(endDateTime), timeZone },
+        colorId: colorId || '1'
+    };
 }

--- a/src/renderer/src/features/event/ui/add-event/AddEventForm.mutation.tsx
+++ b/src/renderer/src/features/event/ui/add-event/AddEventForm.mutation.tsx
@@ -1,7 +1,7 @@
 import { useLogin } from '@/shared/hooks/useLogin';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { CalendarEvent } from '@/shared/types/EventType';
-import { formatDateLocal, makeDateTime, toIsoStringWithOffset } from '@/shared/lib/dateFunction';
+import { createEventBody } from '@/features/event/lib/createEventBody';
 
 interface AddEventProp {
     date: Date;
@@ -59,31 +59,4 @@ export function useAddEvent() {
     });
 
     return { addEvent: addEventMutation.mutate };
-}
-
-function createEventBody({ date, start, end, summary, colorId, allDay }: AddEventProp) {
-    if (allDay) {
-        const startDate = formatDateLocal(date);
-        const endDateObj = new Date(date);
-        endDateObj.setDate(endDateObj.getDate() + 1);
-        const endDate = formatDateLocal(endDateObj);
-
-        return {
-            summary,
-            start: { date: startDate },
-            end: { date: endDate },
-            colorId: colorId || '1'
-        };
-    }
-
-    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const startDateTime = makeDateTime(date, start);
-    const endDateTime = makeDateTime(date, end);
-
-    return {
-        summary,
-        start: { dateTime: toIsoStringWithOffset(startDateTime), timeZone },
-        end: { dateTime: toIsoStringWithOffset(endDateTime), timeZone },
-        colorId: colorId || '1'
-    };
 }

--- a/src/renderer/src/features/event/ui/add-event/AddEventForm.mutation.tsx
+++ b/src/renderer/src/features/event/ui/add-event/AddEventForm.mutation.tsx
@@ -17,7 +17,6 @@ export function useAddEvent() {
 
     const addEventMutation = useMutation({
         mutationKey: ['addEvent'],
-
         mutationFn: async (variables: AddEventProp) => {
             const eventData = createEventBody(variables);
             const response = await fetch(`https://www.googleapis.com/calendar/v3/calendars/primary/events`, {
@@ -38,7 +37,6 @@ export function useAddEvent() {
         onMutate: async (newEvent) => {
             await queryClient.cancelQueries({ queryKey: ['googleCalendarEvents'] });
             const previousData = queryClient.getQueryData<{ items: CalendarEvent[] }>(['googleCalendarEvents']);
-
             const newEventItem = {
                 ...createEventBody(newEvent),
                 id: `temp-id-${Date.now()}`

--- a/src/renderer/src/features/event/ui/edit-event/EditEventForm.mutation.tsx
+++ b/src/renderer/src/features/event/ui/edit-event/EditEventForm.mutation.tsx
@@ -1,7 +1,7 @@
 import { useLogin } from '@/shared/hooks/useLogin';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { CalendarEvent } from '@/shared/types/EventType';
-import { formatDateLocal, makeDateTime, toIsoStringWithOffset } from '@/shared/lib/dateFunction';
+import { createEventBody } from '@/features/event/lib/createEventBody';
 
 interface EditEventProp {
     eventId: string;
@@ -12,7 +12,6 @@ interface EditEventProp {
     colorId: string;
     allDay: boolean;
 }
-
 export function useEditEvent() {
     const { tokens } = useLogin();
     const queryClient = useQueryClient();
@@ -63,31 +62,4 @@ export function useEditEvent() {
     });
 
     return { editEvent: editEventMutation.mutate };
-}
-
-function createEventBody({ date, start, end, summary, colorId, allDay }: Omit<EditEventProp, 'eventId'>) {
-    if (allDay) {
-        const startDate = formatDateLocal(date);
-        const endDateObj = new Date(date);
-        endDateObj.setDate(endDateObj.getDate() + 1);
-        const endDate = formatDateLocal(endDateObj);
-
-        return {
-            summary,
-            start: { date: startDate },
-            end: { date: endDate },
-            colorId: colorId || '1'
-        };
-    }
-
-    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-    const startDateTime = makeDateTime(date, start);
-    const endDateTime = makeDateTime(date, end);
-
-    return {
-        summary,
-        start: { dateTime: toIsoStringWithOffset(startDateTime), timeZone },
-        end: { dateTime: toIsoStringWithOffset(endDateTime), timeZone },
-        colorId: colorId || '1'
-    };
 }

--- a/src/renderer/src/features/event/ui/edit-event/EditEventForm.mutation.tsx
+++ b/src/renderer/src/features/event/ui/edit-event/EditEventForm.mutation.tsx
@@ -1,7 +1,7 @@
 import { useLogin } from '@/shared/hooks/useLogin';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { CalendarEvent } from '@/shared/types/EventType';
-import { formatDateLocal, makeDateTime } from '@/shared/lib/dateFunction';
+import { formatDateLocal, makeDateTime, toIsoStringWithOffset } from '@/shared/lib/dateFunction';
 
 interface EditEventProp {
     eventId: string;
@@ -12,38 +12,15 @@ interface EditEventProp {
     colorId: string;
     allDay: boolean;
 }
+
 export function useEditEvent() {
     const { tokens } = useLogin();
     const queryClient = useQueryClient();
 
     const editEventMutation = useMutation({
         mutationKey: ['editEvent'],
-        mutationFn: async ({ eventId, date, start, end, summary, colorId, allDay }: EditEventProp) => {
-            const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-            let eventData;
-            if (allDay) {
-                // 하루 종일의 경우
-                const startDate = formatDateLocal(date);
-                const endDateObj = new Date(date);
-                endDateObj.setDate(endDateObj.getDate() + 1);
-                const endDate = formatDateLocal(endDateObj);
-                eventData = {
-                    summary,
-                    start: { date: startDate },
-                    end: { date: endDate },
-                    colorId: colorId || '1'
-                };
-            } else {
-                // 아닌 경우
-                const startDateTime = makeDateTime(date, start);
-                const endDateTime = makeDateTime(date, end);
-                eventData = {
-                    summary,
-                    start: { dateTime: startDateTime.toISOString(), timeZone },
-                    end: { dateTime: endDateTime.toISOString(), timeZone },
-                    colorId: colorId || '1'
-                };
-            }
+        mutationFn: async ({ eventId, ...bodyProps }: EditEventProp) => {
+            const eventData = createEventBody(bodyProps);
             const response = await fetch(`https://www.googleapis.com/calendar/v3/calendars/primary/events/${eventId}`, {
                 method: 'PUT',
                 headers: {
@@ -53,56 +30,64 @@ export function useEditEvent() {
                 body: JSON.stringify(eventData)
             });
 
+            if (!response.ok) {
+                throw new Error('Failed to edit event');
+            }
+
             return response.json();
         },
-        onMutate: async (variables) => {
+        onMutate: async ({ eventId, ...bodyProps }) => {
             await queryClient.cancelQueries({ queryKey: ['googleCalendarEvents'] });
-            const previousData = queryClient.getQueryData<{
-                items: CalendarEvent[];
-            }>(['googleCalendarEvents']);
+            const previousData = queryClient.getQueryData<{ items: CalendarEvent[] }>(['googleCalendarEvents']);
+            const updatedEventPart = createEventBody(bodyProps);
+
             if (previousData) {
-                queryClient.setQueryData(['googleCalendarEvents'], () => {
-                    const { eventId, date, start, end, summary, colorId } = variables;
-
-                    const filteredItems = previousData.items.filter((item) => item.id !== eventId);
-                    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
-                    let updatedItem;
-                    if (variables.allDay) {
-                        // 하루 종일의 경우
-                        const startDate = formatDateLocal(date);
-                        const endDateObj = new Date(date);
-                        endDateObj.setDate(endDateObj.getDate() + 1);
-                        const endDate = formatDateLocal(endDateObj);
-                        updatedItem = {
-                            summary,
-                            start: { date: startDate },
-                            end: { date: endDate },
-                            colorId: colorId || '1'
-                        };
-                    } else {
-                        // 아닌 경우
-                        const startDateTime = makeDateTime(date, start);
-                        const endDateTime = makeDateTime(date, end);
-                        updatedItem = {
-                            summary,
-                            start: { dateTime: startDateTime.toISOString(), timeZone },
-                            end: { dateTime: endDateTime.toISOString(), timeZone },
-                            colorId: colorId || '1'
-                        };
-                    }
-
-                    return {
-                        ...previousData,
-                        items: [...filteredItems, updatedItem]
-                    };
+                queryClient.setQueryData(['googleCalendarEvents'], {
+                    items: previousData.items.map((item) => {
+                        if (item.id === eventId) {
+                            return { ...item, ...updatedEventPart, id: eventId };
+                        }
+                        return item;
+                    })
                 });
             }
 
             return { previousData };
         },
-        onError: (_err, _variables, context: any) => queryClient.setQueryData(['googleCalendarEvents'], context.previousData),
+        onError: (_err, _variables, context) => {
+            if (context?.previousData) {
+                queryClient.setQueryData(['googleCalendarEvents'], context.previousData);
+            }
+        },
         onSettled: () => queryClient.invalidateQueries({ queryKey: ['googleCalendarEvents'] })
     });
 
     return { editEvent: editEventMutation.mutate };
+}
+
+function createEventBody({ date, start, end, summary, colorId, allDay }: Omit<EditEventProp, 'eventId'>) {
+    if (allDay) {
+        const startDate = formatDateLocal(date);
+        const endDateObj = new Date(date);
+        endDateObj.setDate(endDateObj.getDate() + 1);
+        const endDate = formatDateLocal(endDateObj);
+
+        return {
+            summary,
+            start: { date: startDate },
+            end: { date: endDate },
+            colorId: colorId || '1'
+        };
+    }
+
+    const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    const startDateTime = makeDateTime(date, start);
+    const endDateTime = makeDateTime(date, end);
+
+    return {
+        summary,
+        start: { dateTime: toIsoStringWithOffset(startDateTime), timeZone },
+        end: { dateTime: toIsoStringWithOffset(endDateTime), timeZone },
+        colorId: colorId || '1'
+    };
 }

--- a/src/renderer/src/shared/lib/dateFunction.ts
+++ b/src/renderer/src/shared/lib/dateFunction.ts
@@ -97,3 +97,24 @@ export function formatDateLocal(date: Date) {
     const day = String(date.getDate()).padStart(2, '0');
     return `${year}-${month}-${day}`;
 }
+
+export function toIsoStringWithOffset(date: Date) {
+    const tzo = -date.getTimezoneOffset();
+    const dif = tzo >= 0 ? '+' : '-';
+    const pad = (num: number) => {
+        const norm = Math.floor(Math.abs(num));
+        return (norm < 10 ? '0' : '') + norm;
+    };
+
+    const year = date.getFullYear();
+    const month = pad(date.getMonth() + 1);
+    const day = pad(date.getDate());
+    const hour = pad(date.getHours());
+    const minute = pad(date.getMinutes());
+    const second = pad(date.getSeconds());
+
+    const offsetHour = pad(tzo / 60);
+    const offsetMinute = pad(tzo % 60);
+
+    return `${year}-${month}-${day}T${hour}:${minute}:${second}${dif}${offsetHour}:${offsetMinute}`;
+}

--- a/src/renderer/src/widgets/Footer/ui/Footer.tsx
+++ b/src/renderer/src/widgets/Footer/ui/Footer.tsx
@@ -42,16 +42,10 @@ export function Footer() {
 
     const upcomingEvent = useMemo(
         () =>
-            items
-                .filter((event) => {
-                    const start = isTimeEvent(event) ? new Date(event.start.dateTime) : new Date(event.start.date);
-                    return start >= tomorrow;
-                })
-                .sort((a, b) => {
-                    const aStart = isTimeEvent(a) ? new Date(a.start.dateTime).getTime() : new Date(a.start.date).getTime();
-                    const bStart = isTimeEvent(b) ? new Date(b.start.dateTime).getTime() : new Date(b.start.date).getTime();
-                    return aStart - bStart;
-                }),
+            items.filter((event) => {
+                const start = isTimeEvent(event) ? new Date(event.start.dateTime) : new Date(event.start.date);
+                return start >= tomorrow;
+            }),
         [items, tomorrow]
     );
 


### PR DESCRIPTION
## 📌 제목

<!-- 어떤 작업인지 간단히 설명 -->

일정을 시간순으로 자동 정렬하게 수정, 1시간 단위 새로고침

## 📝 작업 내용

<!-- PR에서 변경된 내용을 상세히 설명 -->

- 일정을 자동으로 시간순 정렬하게 추가
- 일정을 1시간단위 새로고침하도록 추가
- Footer의 정렬 로직 삭제

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적습니다 -->

Close #68 

## ✅ 체크리스트

- [ ] 테스트 코드 작성
- [ ] 로컬 환경에서 정상 동작 확인
- [ ] ESLint, Prettier 체크 통과
- [ ] 커밋 메시지 규칙 준수

## 📸 스크린샷 (선택)

<!-- UI 변경 시 스크린샷 첨부 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 휴일 이벤트를 별도 소스로 관리하고 설정에 따라 일반 이벤트와 통합해 표시합니다.
  * 이벤트 생성/수정용 공통 페이로드 생성 로직을 도입해 일관성 향상.
  * 타임존 오프셋을 포함한 새로운 날짜 포맷 함수 추가.

* **버그 수정**
  * 이벤트를 시작 시각 기준으로 정렬해 일관된 표시 순서 보장.
  * API 응답 실패 처리 강화 및 오류 복구 조건 개선.
  * 바로 반영(optimistic) 동작 안정성 개선 및 일정 필터 로직 단순화.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->