### PR TITLE
✨ [Feat] 날짜를 누르면 D-Day표시하게 추가

### DIFF
--- a/src/renderer/widgets/Calendar/lib/getDDay.ts
+++ b/src/renderer/widgets/Calendar/lib/getDDay.ts
@@ -1,0 +1,16 @@
+import dayjs from 'dayjs';
+
+export function getDDay(targetDate: Date | string): string {
+  const today = dayjs().startOf('day');
+  const target = dayjs(targetDate).startOf('day');
+
+  const diffDays = target.diff(today, 'day');
+
+  if (diffDays === 0) {
+    return 'Today';
+  }
+  if (diffDays > 0) {
+    return `D-${diffDays}`;
+  }
+  return `D+${Math.abs(diffDays)}`;
+}

--- a/src/renderer/widgets/Calendar/ui/ScheduleModal.tsx
+++ b/src/renderer/widgets/Calendar/ui/ScheduleModal.tsx
@@ -1,11 +1,14 @@
+import { CalendarOff } from 'lucide-react';
 import { useCalendarItems } from '@/entities/event';
 import { AddEventForm, CompleteEventButton, DeleteEventButton, EditEventForm } from '@/features/event';
 
 import { isSameDay } from '@/shared/lib/dateFunction';
 import { DialogContent, DialogHeader, DialogTitle } from '@/shared/ui/dialog';
-import { CalendarOff } from 'lucide-react';
+import { getDDay } from '../lib/getDDay';
 
 export function ScheduleModal({ date }: { date: Date }) {
+  const dDay = getDDay(date);
+  const isToday = dDay === 'Today';
   const { items } = useCalendarItems();
 
   const events = items.filter((event) => {
@@ -16,9 +19,12 @@ export function ScheduleModal({ date }: { date: Date }) {
 
   return (
     <DialogContent>
-      <DialogHeader className="mb-2">
-        <DialogTitle>
-          {date.getMonth() + 1}월 {date.getDate()}일
+      <DialogHeader className="mb-2 text-left">
+        <DialogTitle className="flex flex-row items-baseline gap-3">
+          <span className="text-foreground text-3xl font-bold tracking-tight">
+            {date.getMonth() + 1}월 {date.getDate()}일
+          </span>
+          <span className={`text-secondary text-sm font-medium tracking-wide`}>{isToday ? 'Today' : dDay}</span>
         </DialogTitle>
       </DialogHeader>
       {events.map((event) => (


### PR DESCRIPTION
## 📌 제목

<!-- 어떤 작업인지 간단히 설명 -->

ex) 로그인 기능 구현 (#12)

## 📝 작업 내용

<!-- PR에서 변경된 내용을 상세히 설명 -->

- 로그인 페이지 UI 구현
- 로그인 API 연결 (백엔드 연동)
- JWT 기반 인증 로직 적용

## 🔗 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 적습니다 -->

Close #12

## ✅ 체크리스트

- [ ] 테스트 코드 작성
- [ ] 로컬 환경에서 정상 동작 확인
- [ ] ESLint, Prettier 체크 통과
- [ ] 커밋 메시지 규칙 준수

## 📸 스크린샷 (선택)

<!-- UI 변경 시 스크린샷 첨부 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일정 모달에서 이벤트의 상대적 날짜 상태를 표시하는 상태 배지가 추가되었습니다. "Today", "D-n"(미래 일정), "D+n"(과거 일정) 형식으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->